### PR TITLE
Mark Notifications as Read

### DIFF
--- a/components/NotificationButton.js
+++ b/components/NotificationButton.js
@@ -3,10 +3,15 @@ import { IconButton } from '@mui/material';
 import NotificationsOutlinedIcon from '@mui/icons-material/NotificationsOutlined';
 import Badge from '@mui/material/Badge';
 import useAxios from '../services/api';
+import { styled } from '@mui/material/styles';
+import useMediaQuery from "@mui/material/useMediaQuery";
+import { useTheme } from '@mui/material/styles';
 
 const NotificationButton = ({ token }) => {
   const { axios } = useAxios();
   const [notifications, setNotifications] = useState([]);
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
   useEffect(() => {
     const fetchNotifications = async () => {
@@ -16,9 +21,17 @@ const NotificationButton = ({ token }) => {
     fetchNotifications();
   }, [token]);
 
+  const StyledBadge = styled(Badge)(({ theme }) => ({
+    '& .MuiBadge-badge': {
+      right: -3,
+      top: isMobile ? 10 : 0,
+      border: `2px solid ${theme.palette.background.paper}`,
+      padding: '0 4px',
+    },
+  }));
 
   return (
-    <Badge badgeContent={notifications.length} color="primary">
+    <StyledBadge badgeContent={notifications.length} color="primary">
       <IconButton
         style={{
           background: 'var(--background-color, #090F27)',
@@ -30,7 +43,7 @@ const NotificationButton = ({ token }) => {
       >
         <NotificationsOutlinedIcon htmlColor='#919CC0' />
       </IconButton >
-    </Badge>
+    </StyledBadge>
   );
 };
 

--- a/pages/notifications.js
+++ b/pages/notifications.js
@@ -1,5 +1,5 @@
 import { Stack, Grid } from '@mui/material';
-import React from 'react';
+import React, { useEffect } from 'react';
 import useAxios from "../services/api";
 import NotificationCard from '../components/NotificationCard';
 import { AccountSettingsLayout } from '../components/AccountSettingsLayout';
@@ -8,7 +8,7 @@ import useMediaQuery from "@mui/material/useMediaQuery";
 
 export async function getServerSideProps({ req, res }) {
   const { axios } = useAxios({ req, res });
-  const { data: notifications } = await axios(`/notifications`);
+  const { data: notifications } = await axios(`/notifications/unread`);
   return {
     props: {
       notifications,
@@ -21,15 +21,36 @@ export default function Page({ notifications }) {
   const { results: notificationsList, pagination } = notifications;
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const { axios } = useAxios();
+
+  useEffect(() => {
+    // Define the function to make the PUT request to /notifications/read
+    const markNotificationsAsRead = async () => {
+      try {
+        await axios.patch('/notifications/unread/all', {
+          notification: {
+            read: true
+          }
+        });
+      } catch (error) {
+        console.error('Error marking notifications as read:', error);
+      }
+    };
+
+    // Call the function to mark notifications as read when the component mounts
+    markNotificationsAsRead();
+  }, []); // The empty dependency array ensures this effect runs only on component mount
+
+
   return (
     <Grid item xs={12} md={10} mt={isMobile ? 1.75 : 0}>
-        <Stack spacing={2}>
-          {notificationsList?.map((notification) => {
-            return (
-              <NotificationCard key={notification.id}>{notification}</NotificationCard>
-            );
-          })}  
-        </Stack>
+      <Stack spacing={2}>
+        {notificationsList?.map((notification) => {
+          return (
+            <NotificationCard key={notification.id}>{notification}</NotificationCard>
+          );
+        })}
+      </Stack>
     </Grid>
   );
 }


### PR DESCRIPTION
- Prevents badge count from being cut off on mobile
- Mark all notifications as read when /notifications is visited