### PR TITLE
Fix comments sorting immutability

### DIFF
--- a/components/Chat/MainContent.js
+++ b/components/Chat/MainContent.js
@@ -8,7 +8,7 @@ function MainContent({ comments, focusCommentId: commentId }) {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
 
-  const sortedComments = comments.sort((a, b) => {
+  const sortedComments = comments.slice().sort((a, b) => {
     return new Date(b.created_at) - new Date(a.created_at);
   });
 


### PR DESCRIPTION
## Summary
- keep `comments` prop immutable when sorting

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b87eb81e8832b8baafaa947915abf