### PR TITLE
Fix websocket cleanup

### DIFF
--- a/hooks/useSocket.js
+++ b/hooks/useSocket.js
@@ -45,7 +45,9 @@ export default function useSocket(eventName, channel, params, cb) {
     }
 
     return () => {
-      // ws.close();
+      if (ws && ws.close) {
+        ws.close();
+      }
       console.log('unsubscribe')
     }
   }, [eventName, cb]);


### PR DESCRIPTION
## Summary
- ensure websockets close on cleanup

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b8ddc0ba0832b9896e4615f909167