### PR TITLE
Fix dynamic episode routes

### DIFF
--- a/pages/[show]/[season]/[episode].js
+++ b/pages/[show]/[season]/[episode].js
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export async function getServerSideProps({ params }) {
+  const { show, season, episode } = params;
+
+  return {
+    props: { show, season, episode },
+  };
+}
+
+const EpisodePage = ({ show, season, episode }) => {
+  return (
+    <div style={{ padding: '1rem' }}>
+      <h1>{`Show: ${show}`}</h1>
+      <h2>{`Season: ${season}`}</h2>
+      <h3>{`Episode: ${episode}`}</h3>
+      <p>This dynamic route works on reload and shareable URLs.</p>
+    </div>
+  );
+};
+
+export default EpisodePage;


### PR DESCRIPTION
## Summary
- add `[show]/[season]/[episode]` dynamic page to support deep linking to episodes

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b9b3360cc832bb3c48e2e14e97ec5