### PR TITLE
Add GraceNote episode matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,13 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+## Episode Matcher Utility
+
+The `scripts/runMatcher.js` script fetches episode data from GraceNote and stores
+it in MongoDB. Ensure you have `MONGO_URI`, `DB_NAME` and `GRACENOTE_API_KEY`
+set in your environment before running:
+
+```bash
+node scripts/runMatcher <showId> <gracenoteSeriesId>
+```

--- a/scripts/runMatcher.js
+++ b/scripts/runMatcher.js
@@ -1,0 +1,20 @@
+require('dotenv').config();
+const { matchEpisodes } = require('../services/matcher');
+
+(async () => {
+  const showId = process.argv[2];
+  const gnSeriesId = process.argv[3];
+
+  if (!showId || !gnSeriesId) {
+    console.error('Usage: node runMatcher <showId> <gracenoteSeriesId>');
+    process.exit(1);
+  }
+
+  try {
+    await matchEpisodes(showId, gnSeriesId);
+    console.log('Episode matching completed successfully.');
+  } catch (err) {
+    console.error('Matcher failed:', err);
+    process.exit(1);
+  }
+})();

--- a/services/matcher.js
+++ b/services/matcher.js
@@ -1,0 +1,46 @@
+const axios = require('axios');
+const { MongoClient } = require('mongodb');
+
+/**
+ * Fetch episodes from GraceNote for a series and persist them with the
+ * matching internal show id.
+ * @param {string} showId - Internal show identifier.
+ * @param {string} gracenoteSeriesId - GraceNote series identifier.
+ */
+async function matchEpisodes(showId, gracenoteSeriesId) {
+  const client = new MongoClient(process.env.MONGO_URI);
+
+  try {
+    await client.connect();
+    const db = client.db(process.env.DB_NAME);
+    const episodesCollection = db.collection('episodes');
+
+    const { data } = await axios.get(`https://data.gracenote.com/tv/series/${gracenoteSeriesId}/episodes`, {
+      params: { api_key: process.env.GRACENOTE_API_KEY }
+    });
+
+    const episodes = data.episodes || [];
+    if (!episodes.length) {
+      console.log(`No episodes found for series ${gracenoteSeriesId}`);
+      return;
+    }
+
+    const docs = episodes.map((ep) => ({
+      showId,
+      episodeId: ep.id,
+      title: ep.title,
+      airDate: ep.originalAirDate,
+      metadata: ep
+    }));
+
+    const result = await episodesCollection.insertMany(docs, { ordered: false });
+    console.log(`Inserted ${result.insertedCount} episodes for show ${showId}`);
+  } catch (err) {
+    console.error('Episode matcher error:', err);
+    throw err;
+  } finally {
+    await client.close();
+  }
+}
+
+module.exports = { matchEpisodes };


### PR DESCRIPTION
## Summary
- implement `matchEpisodes` Node utility using MongoDB
- add CLI runner `scripts/runMatcher.js`
- document Episode Matcher usage

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683b9d73b040832b8792a8b2dec0cc0f