### PR TITLE
Fix parsing helper

### DIFF
--- a/components/Chat/MenuSelects.js
+++ b/components/Chat/MenuSelects.js
@@ -7,7 +7,7 @@ import useAxios from "../../services/api";
 
 function parsed(string) {
   const parsedInt = Number.parseInt(string, 10);
-  if (parsedInt === NaN) {
+  if (Number.isNaN(parsedInt)) {
     return 0;
   }
   return parsedInt;


### PR DESCRIPTION
## Summary
- fix `parsed` helper function that checks if parsing failed

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_683b8902d614832b9f128976b8c88de9