### PR TITLE
Fix axios base URL paths

### DIFF
--- a/components/Chat/MenuSelects.js
+++ b/components/Chat/MenuSelects.js
@@ -30,7 +30,7 @@ export const MenuSelects = ({ tmsId, episodes, seasons, onEpisodeSelect, onSortC
   const handleSeasonChange = async (e) => {
     const season = e.target.value;
     setSeason(season);
-    const { data: episodes } = await axios.get(`data/v1.1/series/${tmsId}/episodes?tms_id=${tmsId}&season=${season}&titleLang=en&descriptionLang=en`);
+    const { data: episodes } = await axios.get(`/data/v1.1/series/${tmsId}/episodes?tms_id=${tmsId}&season=${season}&titleLang=en&descriptionLang=en`);
 
 
     const episodesData = episodes.map(({ tmsId, episodeNum, episodeTitle, onEpisodeSelect }) => {

--- a/components/SeasonEpisodeSelector.js
+++ b/components/SeasonEpisodeSelector.js
@@ -21,7 +21,7 @@ const SeasonEpisodeSelector = ({ tmsId, totalSeasons }) => {
   const handleSeasonChange = async (event) => {
     const season = event.target.value;
     setSeason(season);
-    const { data: episodes } = await axios.get(`data/v1.1/series/${tmsId}/episodes?tms_id=${tmsId}&season=${season}&titleLang=en&descriptionLang=en`);
+    const { data: episodes } = await axios.get(`/data/v1.1/series/${tmsId}/episodes?tms_id=${tmsId}&season=${season}&titleLang=en&descriptionLang=en`);
 
 
     const episodeList = episodes.map(({ tmsId, episodeNum, episodeTitle }) => {


### PR DESCRIPTION
## Summary
- add leading slash in episode API endpoints so axios uses baseURL

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683bb24ba050832bad62f417c427a20d