### PR TITLE
Fix parsed helper function

### DIFF
--- a/components/Chat/MenuSelects.js
+++ b/components/Chat/MenuSelects.js
@@ -7,7 +7,7 @@ import useAxios from "../../services/api";
 
 function parsed(string) {
   const parsedInt = Number.parseInt(string, 10)
-  if (parsedInt === NaN) {
+  if (Number.isNaN(parsedInt)) {
     return 0
   };
   return parsedInt;


### PR DESCRIPTION
## Summary
- fix `parsed` helper to detect invalid numbers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683bb24ccb70832ba00ec2616d776a8e