### PR TITLE
Fix EpisodeSelector initial value

### DIFF
--- a/components/SeasonEpisodeSelector.js
+++ b/components/SeasonEpisodeSelector.js
@@ -31,7 +31,7 @@ const SeasonEpisodeSelector = ({ tmsId, totalSeasons }) => {
       }
     });
     setEpisodes(episodeList);
-    setEpisode(episodeList[0]);
+    setEpisode(episodeList[0] ? episodeList[0].value : null);
   }
 
   const handleEpisodeChange = (event) => {


### PR DESCRIPTION
## Summary
- update SeasonEpisodeSelector so episode state stores the id instead of the object

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683bb24d5b60832b8358655ceac77cbe